### PR TITLE
build: upgrade AGP to 9.0.0, Gradle to 9.1.0, and migrate to Android …

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,16 +1,15 @@
 plugins {
     alias(libs.plugins.androidApplication)
-    alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.kotlinCompose)
 }
 
 android {
     namespace = "com.mikhailovskii.inappreview.android"
-    compileSdk = 34
+    compileSdk = 36
     defaultConfig {
         applicationId = "com.mikhailovskii.inappreview.android"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
     }
@@ -31,11 +30,14 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/KMPModuleConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPModuleConventionPlugin.kt
@@ -1,9 +1,10 @@
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import org.gradle.api.Action
 import org.gradle.api.DefaultTask
-import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure
@@ -15,30 +16,25 @@ private class KMPModuleConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
-                apply(extensions.getPluginId("androidLibrary"))
                 apply(extensions.getPluginId("kotlinMultiplatform"))
+                apply(extensions.getPluginId("androidKotlinMultiplatformLibrary"))
                 apply(extensions.getPluginId("mavenPublish"))
             }
             group = "io.github.sergeimikhailovskii"
             version = System.getenv("LIBRARY_VERSION") ?: extensions.getVersion("pluginVersion")
             extensions.configure<KotlinMultiplatformExtension> {
-                androidTarget { publishLibraryVariants("release", "debug") }
+
+                extensions.configure<KotlinMultiplatformAndroidLibraryExtension>("android") {
+                    namespace = "com.mikhailovskii.inappreview"
+
+                    compileSdk = 36
+                    minSdk = 21
+                }
                 iosX64()
                 iosArm64()
                 iosSimulatorArm64()
                 applyDefaultHierarchyTemplate()
                 jvmToolchain(24)
-            }
-            extensions.configure<LibraryExtension> {
-                namespace = "com.mikhailovskii.inappreview"
-                compileSdk = 34
-                defaultConfig {
-                    minSdk = 21
-                }
-                compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_24
-                    targetCompatibility = JavaVersion.VERSION_24
-                }
             }
             extensions.configure<PublishingExtension> {
                 publications.withType<MavenPublication> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     //trick: for the same plugin versions in all sub-modules
     alias(libs.plugins.androidApplication).apply(false)
     alias(libs.plugins.androidLibrary).apply(false)
-    alias(libs.plugins.kotlinAndroid).apply(false)
+    alias(libs.plugins.androidKotlinMultiplatformLibrary).apply(false)
     alias(libs.plugins.kotlinMultiplatform).apply(false)
     alias(libs.plugins.kotlinCocoapods).apply(false)
     alias(libs.plugins.kotlinCompose).apply(false)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 pluginVersion = "2.0.0-rc01"
-agp = "8.12.0"
+agp = "9.0.0"
 kotlin = "2.2.20"
 compose = "1.9.1"
 compose-compiler = "1.5.11-dev-k1.9.23-96ef9dc6af1"
@@ -32,7 +32,7 @@ maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
-kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/in-app-review-kmp-sample/build.gradle.kts
+++ b/in-app-review-kmp-sample/build.gradle.kts
@@ -1,11 +1,15 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidKotlinMultiplatformLibrary)
     alias(libs.plugins.kotlinCocoapods)
-    alias(libs.plugins.androidLibrary)
 }
 
 kotlin {
-    androidTarget()
+    androidLibrary {
+        namespace = "com.mikhailovskii.inappreviewkmp_sample"
+        compileSdk = 36
+        minSdk = 26
+    }
     iosX64()
     iosArm64()
     iosSimulatorArm64()
@@ -29,13 +33,5 @@ kotlin {
             implementation(projects.inAppReviewKmpRustore)
             implementation(libs.coroutines.core)
         }
-    }
-}
-
-android {
-    namespace = "com.mikhailovskii.inappreviewkmp_sample"
-    compileSdk = 34
-    defaultConfig {
-        minSdk = 26
     }
 }


### PR DESCRIPTION
…KMP Library plugin

- Upgrade Android Gradle Plugin (AGP) to 9.0.0 and Gradle wrapper to 9.1.0.
- Migrate from `com.android.library` to `com.android.kotlin.multiplatform.library` in KMP modules.
- Update `compileSdk` and `targetSdk` to 36.
- Update `androidApp` to use Java 17 and `jvmTarget` 17.
- Refactor `KMPModuleConventionPlugin` to use `KotlinMultiplatformAndroidLibraryExtension`.